### PR TITLE
Fixes and tweaks to support apsync along with Nvidia TX2

### DIFF
--- a/files/apsync/video.html
+++ b/files/apsync/video.html
@@ -11,7 +11,7 @@
 <body>
 
 <p><a href="/index.html"><img src="/images/main_logo.png" alt="ArduPilot"></a></p>
-<h1>Video Streaming</h1>
+<h1>Video Streaming - (for UDP Streaming use Cherrypy instead)</h1>
 <div id="serverStoppedDiv">
 <p>Network Interface: <select id="if_select_box"></select><button type="submit" style="padding:1px" value="set_if" onclick="start_server();">Start RTSP Server</button></p>
 </div>
@@ -21,6 +21,9 @@
 </table>
 <p><input type="submit" name="action" value="Stop RTSP Server" onclick="stop_server();"></p>
 </div>
+<hr>
+<p><a href="/index.html">home</a>
+
 <script>
     var VideoPresetsEnum = {
         VIDEO_320x240x15: 0, VIDEO_640x480x15: 1, VIDEO_1280x720x15: 2,

--- a/files/filesystem.html
+++ b/files/filesystem.html
@@ -12,7 +12,7 @@
 
 <p><a href="index.html"><img src="images/main_logo.png" alt="ArduPilot"></a></p>
 
-<h2>ArduPilot Filesystem</h2>
+<h2>ArduPilot Companion Computer Filesystem</h2>
 
 <h1>Index of <b id="directory_name">/</b></h1>
 

--- a/files/index.html
+++ b/files/index.html
@@ -15,14 +15,12 @@
 
 <h2>ArduPilot Web Server</h2>
 
-Welcome to the ArduPilot Web Interface!<p>
+Welcome to the ArduPilot Web Interface for Nvidia Jetson TX2<p>
 
   <ul>
     <li><a href="filesystem.html?start_directory=/home/apsync/dflogger/dataflash">Download DataFlash Logs</a></li>
     <li><a href="filesystem.html">Filesystem access</a></li>
-    <li><a href="apsync/system.html">System control</a></li>
     <li><a href="apsync/status.html">System Status</a></li>
-    <li><a href="apsync/calibration.html">Calibration</a></li>
     <li><a href="parameters.html">Flight Parameters</a></li>
     <li><a href="apsync/video.html">Video Streaming</a></li>
   </ul>

--- a/functions.c
+++ b/functions.c
@@ -813,7 +813,8 @@ static void start_rtsp_server(struct template_state *tmpl, const char *name, con
         } else if (stream_server_pid == 0) {
             char* home_dir;
             char stream_server_path[256];
-            home_dir = getenv("HOME");
+//            home_dir = getenv("HOME");
+            home_dir = "/home/apsync"; // fix the path issue when executed from /etc/rc.local
             sprintf(stream_server_path, "%s/start_apstreamline/bin/stream_server", home_dir);
             printf("%s", stream_server_path);
             if (execl(stream_server_path, "stream_server", argv[0], NULL)==-1) {


### PR DESCRIPTION
Fixed the $HOME path issue in functions.c by adding the path to the apsync home directory.
stream_server can now be started also when the web_server is launched from /etc/rc.local.
The APWeb menus and screens are adopted to the TX2 supported capabilities.